### PR TITLE
user-provided file template

### DIFF
--- a/rio_toa/scripts/cli.py
+++ b/rio_toa/scripts/cli.py
@@ -21,13 +21,14 @@ def toa():
 @click.argument('src_mtl', type=click.Path(exists=True))
 @click.argument('dst_path', type=click.Path(exists=False))
 @click.option('--dst-dtype', type=click.Choice(['float64']), default='float64')
+@click.option('--readtemplate', '-t', default=".*/LC8.*\_B{b}.TIF", help="File path template [default='.*/LC8.*\_B{b}.TIF']")
 @click.option('--workers', '-j', type=int, default=4)
 @click.option('--l8-bidx', default=0,
     help="L8 Band that the src_path represents (Default is parsed from file name)")
 @click.option('--verbose', '-v', is_flag=True, default=False)
 @click.pass_context
 @creation_options
-def radiance(ctx, src_path, src_mtl, dst_path,
+def radiance(ctx, src_path, src_mtl, dst_path, readtemplate,
          verbose, creation_options, l8_bidx, dst_dtype, workers):
     """Calculates Landsat8 Surface Radiance
     """
@@ -35,8 +36,7 @@ def radiance(ctx, src_path, src_mtl, dst_path,
         logger.setLevel(logging.DEBUG)
 
     if l8_bidx == 0:
-        template = '.*\LC8.*_B{b}.TIF'
-        l8_bidx = _parse_bands_from_filename([src_path], template)[0]
+        l8_bidx = _parse_bands_from_filename([src_path], readtemplate)[0]
     elif not isinstance(l8_bidx, int):
         raise ValueError("%s is not a valid integer" % l8_bidx)
 

--- a/rio_toa/scripts/cli.py
+++ b/rio_toa/scripts/cli.py
@@ -1,7 +1,7 @@
 
 import logging
 
-import click, json
+import click, json, re
 from rasterio.rio.options import creation_options
 from rio_toa.radiance import calculate_landsat_radiance
 from rio_toa.reflectance import calculate_landsat_reflectance
@@ -47,13 +47,14 @@ def radiance(ctx, src_path, src_mtl, dst_path,
 @click.argument('src_mtl', type=click.Path(exists=True))
 @click.argument('dst_path', type=click.Path(exists=False))
 @click.option('--dst-dtype', type=click.Choice(['float32']), default='float32')
+@click.option('--readtemplate', '-t', default=".*/LC8.*\_B{b}.TIF", help="File path template [default='.*/LC8.*\_B{b}.TIF']")
 @click.option('--workers', '-j', type=int, default=4)
 @click.option('--l8-bidx', default=0,
     help="L8 Band that the src_path represents (Default is parsed from file name)")
 @click.option('--verbose', '-v', is_flag=True, default=False)
 @click.pass_context
 @creation_options
-def reflectance(ctx, src_path, src_mtl, dst_path,
+def reflectance(ctx, src_path, src_mtl, dst_path, readtemplate,
          verbose, creation_options, l8_bidx, dst_dtype, workers):
     """Calculates Landsat8 Surface Reflectance
     """
@@ -61,8 +62,7 @@ def reflectance(ctx, src_path, src_mtl, dst_path,
         logger.setLevel(logging.DEBUG)
 
     if l8_bidx == 0:
-        template =  '.*\LC8.*_B{b}.TIF'
-        l8_bidx = _parse_bands_from_filename([src_path], template)[0]
+        l8_bidx = _parse_bands_from_filename([src_path], readtemplate)[0]
     elif not isinstance(l8_bidx, int):
         raise ValueError("%s is not a valid integer" % l8_bidx)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,18 +10,43 @@ from rasterio.rio.options import creation_options
 from rio_toa.scripts.cli import radiance, reflectance, parsemtl
 
 
-def test_cli_radiance(tmpdir):
+def test_cli_radiance_default(tmpdir):
+    output = str(tmpdir.join('toa_radiance.tif'))
+    runner = CliRunner()
+    result = runner.invoke(radiance, 
+        ['tests/data/LC81060712016134LGN00_B3.TIF',
+         'tests/data/LC81060712016134LGN00_MTL.json',
+         output])
+    assert result.exit_code == 0
+    assert os.path.exists(output)
+    with rasterio.open(output) as out:
+        assert out.count == 1
+        assert out.dtypes[0] == rasterio.float64
+
+def test_cli_radiance_good(tmpdir):
+    output = str(tmpdir.join('toa_radiance.tif'))
+    runner = CliRunner()
+    result = runner.invoke(radiance, 
+        ['tests/data/tiny_LC80100202015018LGN00_B1.TIF',
+         'tests/data/LC80100202015018LGN00_MTL.json',
+         output, '--readtemplate', '.*/tiny_LC8.*\_B{b}.TIF'])
+    assert result.exit_code == 0
+    assert os.path.exists(output)
+    with rasterio.open(output) as out:
+        assert out.count == 1
+        assert out.dtypes[0] == rasterio.float64
+
+def test_cli_radiance_fail(tmpdir):
     output = str(tmpdir.join('toa_radiance.tif'))
     runner = CliRunner()
     result = runner.invoke(radiance, 
         ['tests/data/tiny_LC80100202015018LGN00_B1.TIF',
          'tests/data/LC80100202015018LGN00_MTL.json',
          output])
-    assert result.exit_code == 0
-    assert os.path.exists(output)
+    assert result.exit_code != 0
 
 
-def test_cli_reflectance(tmpdir):
+def test_cli_reflectance_default(tmpdir):
     output = str(tmpdir.join('toa_reflectance.tif'))
     runner = CliRunner()
     result = runner.invoke(reflectance, 
@@ -33,7 +58,8 @@ def test_cli_reflectance(tmpdir):
         assert out.count == 1
         assert out.dtypes[0] == rasterio.float32
 
-def test_cli_reflectance_readtemplate(tmpdir):
+
+def test_cli_reflectance_good(tmpdir):
     output = str(tmpdir.join('toa_reflectance_readtemplate.TIF'))
     runner = CliRunner()
     result = runner.invoke(reflectance, 
@@ -45,7 +71,18 @@ def test_cli_reflectance_readtemplate(tmpdir):
         assert out.count == 1
         assert out.dtypes[0] == rasterio.float32
 
-def test_cli_parsemtl(tmpdir):
+
+def test_cli_reflectance_fail(tmpdir):
+    output = str(tmpdir.join('toa_reflectance_readtemplate.TIF'))
+    runner = CliRunner()
+    result = runner.invoke(reflectance, 
+        ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
+         'tests/data/LC81390452014295LGN00_MTL.json',
+         output])
+    assert result.exit_code != 0
+
+
+def test_cli_parsemtl_good(tmpdir):
     runner = CliRunner()
     result = runner.invoke(parsemtl,
         ['tests/data/mtltest_LC80100202015018LGN00_MTL.txt'])
@@ -58,3 +95,11 @@ def test_cli_parsemtl(tmpdir):
                     "PRODUCT_METADATA": {"SCENE_CENTER_TIME":
                     "15:10:22.4142571Z", "DATE_ACQUIRED": "2015-01-18",
                     "DATA_TYPE": "L1T"}}})
+
+
+def test_cli_parsemtl_fail(tmpdir):
+    runner = CliRunner()
+    result = runner.invoke(parsemtl,
+        ['tests/data/tiny_mtltest_LC80100202015018LGN00_MTL.txt'])
+    assert result.exit_code != 0
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,7 @@ def test_cli_radiance_fail(tmpdir):
     result = runner.invoke(radiance, 
         ['tests/data/tiny_LC80100202015018LGN00_B1.TIF',
          'tests/data/LC80100202015018LGN00_MTL.json',
-         output])
+         output, '.*/Fail_LC8.*\_B{b}.TIF'])
     assert result.exit_code != 0
 
 
@@ -79,6 +79,16 @@ def test_cli_reflectance_fail(tmpdir):
         ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
          'tests/data/LC81390452014295LGN00_MTL.json',
          output])
+    assert result.exit_code != 0
+
+
+def test_cli_reflectance_fail2(tmpdir):
+    output = str(tmpdir.join('toa_reflectance_readtemplate.TIF'))
+    runner = CliRunner()
+    result = runner.invoke(reflectance, 
+        ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
+         'tests/data/LC81390452014295LGN00_MTL.json',
+         output, '.*/Fail_LC8.*\_B{b}.TIF'])
     assert result.exit_code != 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,14 +25,25 @@ def test_cli_reflectance(tmpdir):
     output = str(tmpdir.join('toa_reflectance.tif'))
     runner = CliRunner()
     result = runner.invoke(reflectance, 
-        ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
-         'tests/data/LC81390452014295LGN00_MTL.json',
+        ['tests/data/LC81060712016134LGN00_B3.TIF',
+         'tests/data/LC81060712016134LGN00_MTL.json',
          output])
     assert result.exit_code == 0
     with rasterio.open(output) as out:
         assert out.count == 1
         assert out.dtypes[0] == rasterio.float32
 
+def test_cli_reflectance_readtemplate(tmpdir):
+    output = str(tmpdir.join('toa_reflectance_readtemplate.TIF'))
+    runner = CliRunner()
+    result = runner.invoke(reflectance, 
+        ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
+         'tests/data/LC81390452014295LGN00_MTL.json',
+         output, '--readtemplate', '.*/tiny_LC8.*\_B{b}.TIF'])
+    assert result.exit_code == 0
+    with rasterio.open(output) as out:
+        assert out.count == 1
+        assert out.dtypes[0] == rasterio.float32
 
 def test_cli_parsemtl(tmpdir):
     runner = CliRunner()

--- a/tests/test_toa_utils.py
+++ b/tests/test_toa_utils.py
@@ -13,6 +13,9 @@ def test_parse_band_from_filename_bad():
 	with pytest.raises(ValueError):
 		_parse_bands_from_filename(['LC81070352015122LGN00_B3.tif'], 'LC8NOGOOD.*_B{b}.tif')
 
+def test_parse_band_from_filename_bad2():
+	with pytest.raises(ValueError):
+		_parse_bands_from_filename(['tiny_LC81070352015122LGN00_B3.tif'], 'LC8.*_B{b}.tif')
 
 def test_load_mtl():
 	src_mtl = 'tests/data/LC80100202015018LGN00_MTL.json'

--- a/tests/test_toa_utils.py
+++ b/tests/test_toa_utils.py
@@ -4,23 +4,29 @@ from rio_toa.toa_utils import (
 	_parse_bands_from_filename,
 	_load_mtl_key, _load_mtl)
 
+def test_parse_band_from_filename_default():
+	assert _parse_bands_from_filename(['data/LC81070352015122LGN00_B3.TIF'], '.*/LC8.*\_B{b}.TIF') == [3]
+
 
 def test_parse_band_from_filename_good():
-	assert _parse_bands_from_filename(['LC81070352015122LGN00_B3.tif'], 'LC8.*_B{b}.tif') == [3]
+	assert _parse_bands_from_filename(['tiny_LC81070352015122LGN00_B3.tif'], 'tiny_LC8.*_B{b}.tif') == [3]
 
 
 def test_parse_band_from_filename_bad():
 	with pytest.raises(ValueError):
 		_parse_bands_from_filename(['LC81070352015122LGN00_B3.tif'], 'LC8NOGOOD.*_B{b}.tif')
 
+
 def test_parse_band_from_filename_bad2():
 	with pytest.raises(ValueError):
-		_parse_bands_from_filename(['tiny_LC81070352015122LGN00_B3.tif'], 'LC8.*_B{b}.tif')
+		_parse_bands_from_filename(['data/tiny_LC81070352015122LGN00_B3.tif'], '.*/LC8.*\_B{b}.TIF')
+
 
 def test_load_mtl():
 	src_mtl = 'tests/data/LC80100202015018LGN00_MTL.json'
 	mtl = _load_mtl(src_mtl)
 	assert isinstance(mtl, dict)
+
 
 def test_load_txt_mtl_1():
 	txtmtl = _load_mtl('tests/data/LC81060712016134LGN00_MTL.txt')


### PR DESCRIPTION
Adding the option for user-provided filename template with a default of `LC8.*\_B{b}.TIF`, where {b} is the band # to be extracted.

Ticket: https://github.com/mapbox/rio-toa/issues/9
