### PR TITLE
User friendlier

### DIFF
--- a/rio_toa/radiance.py
+++ b/rio_toa/radiance.py
@@ -11,8 +11,9 @@ def radiance(img, ML, AL, src_nodata=0):
     as outlined here: http://landsat.usgs.gov/Landsat8_Using_Product.php
 
     L = ML * Q + AL
+    
     where:
-        L  = TOA spectral radiance (Watts/( m2 * srad * mm))
+        L  = TOA spectral radiance (Watts / (m2 * srad * mm))
         ML = Band-specific multiplicative rescaling factor from the metadata
              (RADIANCE_MULT_BAND_x, where x is the band number)
         AL = Band-specific additive rescaling factor from the metadata
@@ -32,7 +33,7 @@ def radiance(img, ML, AL, src_nodata=0):
     Returns
     --------
     ndarray:
-        float64 ndarray with shape == input shape
+        float32 ndarray with shape == input shape
     """
 
     rs = ML * img.astype(np.float32) + AL

--- a/rio_toa/radiance.py
+++ b/rio_toa/radiance.py
@@ -11,7 +11,7 @@ def radiance(img, ML, AL, src_nodata=0):
     as outlined here: http://landsat.usgs.gov/Landsat8_Using_Product.php
 
     L = ML * Q + AL
-    
+
     where:
         L  = TOA spectral radiance (Watts / (m2 * srad * mm))
         ML = Band-specific multiplicative rescaling factor from the metadata
@@ -48,12 +48,15 @@ def _radiance_worker(data, window, ij, g_args):
     TODO: integrate rescaling functionality for
     different output datatypes
     """
-    output = toa_utils.rescale(radiance(
+    output = toa_utils.rescale(
+                radiance(
                     data[0],
                     g_args['M'],
                     g_args['A'],
                     g_args['src_nodata']),
-                g_args['rescale_factor'], g_args['dst_dtype'])
+                g_args['rescale_factor'],
+                g_args['dst_dtype'])
+
     return output
 
 

--- a/rio_toa/reflectance.py
+++ b/rio_toa/reflectance.py
@@ -16,15 +16,13 @@ def reflectance(img, MR, AR, E, src_nodata=0):
 
     R_raw = MR * Q + AR
 
-    R =    R_raw / cos(Z) =   R_raw / sin(E)
+    R = R_raw / cos(Z) = R_raw / sin(E)
 
-    Z = 90 - np.radians(E)
-
-
+    Z = 90 - E (in degrees)
+    
     where:
 
         R_raw = TOA planetary reflectance, without correction for solar angle.
-                Note that P does not contain a correction for the sun angle.
         R = TOA reflectance with a correction for the sun angle.
         MR = Band-specific multiplicative rescaling factor from the metadata
             (REFLECTANCE_MULT_BAND_x, where x is the band number)
@@ -33,13 +31,13 @@ def reflectance(img, MR, AR, E, src_nodata=0):
         Q = Quantized and calibrated standard product pixel values (DN)
         E = Local sun elevation angle. The scene center sun elevation angle
             in degrees is provided in the metadata (SUN_ELEVATION).
-        Z = Local solar zenith angle
+        Z = Local solar zenith angle (same angle as E, but measured from the
+            zenith instead of from the horizon).
 
     Parameters
     -----------
     img: ndarray
         array of input pixels of shape (rows, cols) or (rows, cols, depth)
-
     MR: float or list of floats
         multiplicative rescaling factor from scene metadata
     AR: float or list of floats
@@ -53,6 +51,7 @@ def reflectance(img, MR, AR, E, src_nodata=0):
         float32 ndarray with shape == input shape
 
     """
+    
     if np.any(E < 0.0):
         raise ValueError("Sun Elevation Must Be Nonnegative")
 

--- a/rio_toa/reflectance.py
+++ b/rio_toa/reflectance.py
@@ -169,7 +169,11 @@ def calculate_landsat_reflectance(src_paths, src_mtl, dst_path, rescale_factor,
     }
 
     dst_profile.update(count=len(bands))
-    dst_profile.update(photometric='rgb')
+    
+    if len(bands) == 3:
+      dst_profile.update(photometric='rgb')
+    else:
+      dst_profile.update(photometric='minisblack')
 
     with riomucho.RioMucho(list(src_paths),
                            dst_path,

--- a/rio_toa/scripts/cli.py
+++ b/rio_toa/scripts/cli.py
@@ -24,8 +24,8 @@ def toa():
 @click.argument('src_mtl', type=click.Path(exists=True))
 @click.argument('dst_path', type=click.Path(exists=False))
 @click.option('--dst-dtype',
-              type=click.Choice(['float32', 'float64', 'uint16', 'uint8']),
-              default='float32')
+              type=click.Choice(['uint16', 'uint8']),
+              default='uint16')
 @click.option('--rescale-factor', '-r',
               type=float,
               default=float(55000.0/2**16),
@@ -60,8 +60,8 @@ def radiance(ctx, src_path, src_mtl, dst_path, rescale_factor,
 @click.argument('src_mtl', type=click.Path(exists=True))
 @click.argument('dst_path', type=click.Path(exists=False))
 @click.option('--dst-dtype',
-              type=click.Choice(['float32', 'float64', 'uint16', 'uint8']),
-              default='float32')
+              type=click.Choice(['uint16', 'uint8']),
+              default='uint16')
 @click.option('--rescale-factor', '-r',
               type=float,
               default=float(55000.0/2**16),

--- a/rio_toa/toa_utils.py
+++ b/rio_toa/toa_utils.py
@@ -120,10 +120,9 @@ def _get_bounds_from_metadata(product_metadata):
 def rescale(arr, rescale_factor, dtype):
     """Convert an array from 0..1 to dtype, scaling up linearly
     """
-    if dtype == np.__dict__['uint8']:
-        arr *= rescale_factor * np.iinfo(np.uint8).max
-        return np.clip(arr, 1, np.iinfo(np.uint8).max).astype(dtype)
 
-    else:
-        arr *= rescale_factor * np.iinfo(np.uint16).max
-        return np.clip(arr, 1, np.iinfo(np.uint16).max).astype(dtype)
+    if dtype not in [np.uint8, np.uint16]:
+      raise ValueError('Rescaling converts to uint{8,16} only')
+    
+    arr *= rescale_factor * np.iinfo(dtype).max
+    return np.clip(arr, 1, np.iinfo(dtype).max).astype(dtype)

--- a/rio_toa/toa_utils.py
+++ b/rio_toa/toa_utils.py
@@ -17,28 +17,26 @@ def _parse_bands_from_filename(filenames, template):
 
 def _load_mtl_key(mtl, keys, band=None):
     """
-    Loads metadata from a Landsat MTL dict based on an arbitrary set of keys
+    Loads requested metadata from a Landsat MTL dict
 
     Parameters
     -----------
     mtl: dict
         parsed Landsat 8 MTL metadata
     keys: iterable
-        an interable of arbitrary length that contains
-        successive dict hashes for mtl
+        a list containing arbitrary keys to load from the MTL
     band: int
-        band number to join to last key value.
-        ignored if None or if not int
+        band number to join to last key value
+        (ignored if not int)
 
     Returns
     --------
-    output: any value or object
-        the resulting value or object
-        from key hash succession
+    output: any value
+        the value corresponding to the provided key in the MTL
     """
     keys = list(keys)
 
-    if band is not None and isinstance(band, int):
+    if isinstance(band, int):
         keys[-1] = '%s%s' % (keys[-1], band)
 
     # for each key, the mtl is winnowed down by each key hash
@@ -90,14 +88,14 @@ def _parse_mtl_txt(mtltxt):
 
 
 def _cast_to_best_type(kd):
-        key, data = kd[0]
+    key, data = kd[0]
+    try:
+        return key, int(data)
+    except ValueError as err:
         try:
-            return key, int(data)
+            return key, float(data)
         except ValueError as err:
-            try:
-                return key, float(data)
-            except ValueError as err:
-                return key, u'{}'.format(data.strip('"'))
+            return key, u'{}'.format(data.strip('"'))
 
 
 def _parse_data(line):

--- a/rio_toa/toa_utils.py
+++ b/rio_toa/toa_utils.py
@@ -122,7 +122,7 @@ def rescale(arr, rescale_factor, dtype):
     """
 
     if dtype not in [np.uint8, np.uint16]:
-      raise ValueError('Rescaling converts to uint{8,16} only')
-    
+        raise ValueError('Rescaling converts to uint{8,16} only')
+
     arr *= rescale_factor * np.iinfo(dtype).max
     return np.clip(arr, 1, np.iinfo(dtype).max).astype(dtype)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ def test_cli_radiance_default(tmpdir):
     assert os.path.exists(output)
     with rasterio.open(output) as out:
         assert out.count == 1
-        assert out.dtypes[0] == rasterio.float32
+        assert out.dtypes[0] == rasterio.uint16
 
 def test_cli_radiance_good(tmpdir):
     output = str(tmpdir.join('toa_radiance.tif'))
@@ -35,7 +35,7 @@ def test_cli_radiance_good(tmpdir):
     assert os.path.exists(output)
     with rasterio.open(output) as out:
         assert out.count == 1
-        assert out.dtypes[0] == rasterio.float32
+        assert out.dtypes[0] == rasterio.uint16
 
 def test_cli_radiance_fail(tmpdir):
     output = str(tmpdir.join('toa_radiance.tif'))
@@ -57,7 +57,7 @@ def test_cli_reflectance_default(tmpdir):
     assert result.exit_code == 0
     with rasterio.open(output) as out:
         assert out.count == 1
-        assert out.dtypes[0] == rasterio.float32
+        assert out.dtypes[0] == rasterio.uint16
 
 
 def test_cli_reflectance_good(tmpdir):
@@ -70,7 +70,7 @@ def test_cli_reflectance_good(tmpdir):
     assert result.exit_code == 0
     with rasterio.open(output) as out:
         assert out.count == 1
-        assert out.dtypes[0] == rasterio.float32
+        assert out.dtypes[0] == rasterio.uint16
 
 
 def test_cli_reflectance_l8_bidx(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,46 +14,52 @@ from rio_toa.scripts.cli import radiance, reflectance, parsemtl
 def test_cli_radiance_default(tmpdir):
     output = str(tmpdir.join('toa_radiance.tif'))
     runner = CliRunner()
-    result = runner.invoke(radiance, 
-        ['tests/data/LC81060712016134LGN00_B3.TIF',
-         'tests/data/LC81060712016134LGN00_MTL.json',
-         output])
+    result = runner.invoke(
+                radiance,
+                ['tests/data/LC81060712016134LGN00_B3.TIF',
+                 'tests/data/LC81060712016134LGN00_MTL.json',
+                 output])
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
         assert out.count == 1
         assert out.dtypes[0] == rasterio.uint16
+
 
 def test_cli_radiance_good(tmpdir):
     output = str(tmpdir.join('toa_radiance.tif'))
     runner = CliRunner()
-    result = runner.invoke(radiance, 
-        ['tests/data/tiny_LC80100202015018LGN00_B1.TIF',
-         'tests/data/LC80100202015018LGN00_MTL.json',
-         output, '--readtemplate', '.*/tiny_LC8.*\_B{b}.TIF'])
+    result = runner.invoke(
+                radiance,
+                ['tests/data/tiny_LC80100202015018LGN00_B1.TIF',
+                 'tests/data/LC80100202015018LGN00_MTL.json',
+                 output, '--readtemplate', '.*/tiny_LC8.*\_B{b}.TIF'])
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
         assert out.count == 1
         assert out.dtypes[0] == rasterio.uint16
 
+
 def test_cli_radiance_fail(tmpdir):
     output = str(tmpdir.join('toa_radiance.tif'))
     runner = CliRunner()
-    result = runner.invoke(radiance, 
-        ['tests/data/tiny_LC80100202015018LGN00_B1.TIF',
-         'tests/data/LC80100202015018LGN00_MTL.json',
-         output, '.*/Fail_LC8.*\_B{b}.TIF'])
+    result = runner.invoke(
+                radiance,
+                ['tests/data/tiny_LC80100202015018LGN00_B1.TIF',
+                 'tests/data/LC80100202015018LGN00_MTL.json',
+                 output, '.*/Fail_LC8.*\_B{b}.TIF'])
     assert result.exit_code != 0
 
 
 def test_cli_reflectance_default(tmpdir):
     output = str(tmpdir.join('toa_reflectance.tif'))
     runner = CliRunner()
-    result = runner.invoke(reflectance, 
-        ['tests/data/LC81060712016134LGN00_B3.TIF',
-         'tests/data/LC81060712016134LGN00_MTL.json',
-         output])
+    result = runner.invoke(
+                reflectance,
+                ['tests/data/LC81060712016134LGN00_B3.TIF',
+                 'tests/data/LC81060712016134LGN00_MTL.json',
+                 output])
     assert result.exit_code == 0
     with rasterio.open(output) as out:
         assert out.count == 1
@@ -63,10 +69,11 @@ def test_cli_reflectance_default(tmpdir):
 def test_cli_reflectance_good(tmpdir):
     output = str(tmpdir.join('toa_reflectance_readtemplate.TIF'))
     runner = CliRunner()
-    result = runner.invoke(reflectance, 
-        ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
-         'tests/data/LC81390452014295LGN00_MTL.json',
-         output, '--readtemplate', '.*/tiny_LC8.*\_B{b}.TIF'])
+    result = runner.invoke(
+                reflectance,
+                ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
+                 'tests/data/LC81390452014295LGN00_MTL.json',
+                 output, '--readtemplate', '.*/tiny_LC8.*\_B{b}.TIF'])
     assert result.exit_code == 0
     with rasterio.open(output) as out:
         assert out.count == 1
@@ -76,10 +83,11 @@ def test_cli_reflectance_good(tmpdir):
 def test_cli_reflectance_l8_bidx(tmpdir):
     output = str(tmpdir.join('toa_reflectance.tif'))
     runner = CliRunner()
-    result = runner.invoke(reflectance, 
-        ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
-         'tests/data/LC81390452014295LGN00_MTL.json',
-         output, '--l8-bidx', 'notint'])
+    result = runner.invoke(
+                reflectance,
+                ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
+                 'tests/data/LC81390452014295LGN00_MTL.json',
+                 output, '--l8-bidx', 'notint'])
     assert result.exit_code != 0
     assert 'Error: Invalid value for "--l8-bidx":' \
            ' notint is not a valid integer\n' in result.output
@@ -88,32 +96,36 @@ def test_cli_reflectance_l8_bidx(tmpdir):
 def test_cli_reflectance_fail(tmpdir):
     output = str(tmpdir.join('toa_reflectance_readtemplate.TIF'))
     runner = CliRunner()
-    result = runner.invoke(reflectance, 
-        ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
-         'tests/data/LC81390452014295LGN00_MTL.json',
-         output])
+    result = runner.invoke(
+                reflectance,
+                ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
+                 'tests/data/LC81390452014295LGN00_MTL.json',
+                 output])
     assert result.exit_code != 0
 
 
 def test_cli_reflectance_fail2(tmpdir):
     output = str(tmpdir.join('toa_reflectance_readtemplate.TIF'))
     runner = CliRunner()
-    result = runner.invoke(reflectance, 
-        ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
-         'tests/data/LC81390452014295LGN00_MTL.json',
-         output, '.*/Fail_LC8.*\_B{b}.TIF'])
+    result = runner.invoke(
+                reflectance,
+                ['tests/data/tiny_LC81390452014295LGN00_B5.TIF',
+                 'tests/data/LC81390452014295LGN00_MTL.json',
+                 output, '.*/Fail_LC8.*\_B{b}.TIF'])
     assert result.exit_code != 0
 
 
 def test_cli_reflectance_multiband_stack(tmpdir):
     output = str(tmpdir.join('toa_reflectance_multiband_stack.TIF'))
     runner = CliRunner()
-    result = runner.invoke(reflectance,
-        ['tests/data/tiny_LC80460282016177LGN00_B2.TIF',
-         'tests/data/tiny_LC80460282016177LGN00_B3.TIF',
-         'tests/data/tiny_LC80460282016177LGN00_B4.TIF',
-         'tests/data/LC80460282016177LGN00_MTL.json',
-          output, '-t', '.*/tiny_LC8.*\_B{b}.TIF', '--dst-dtype', 'uint16'])
+    result = runner.invoke(
+                reflectance,
+                ['tests/data/tiny_LC80460282016177LGN00_B2.TIF',
+                 'tests/data/tiny_LC80460282016177LGN00_B3.TIF',
+                 'tests/data/tiny_LC80460282016177LGN00_B4.TIF',
+                 'tests/data/LC80460282016177LGN00_MTL.json',
+                 output, '-t', '.*/tiny_LC8.*\_B{b}.TIF',
+                 '--dst-dtype', 'uint16'])
     assert len(os.listdir(str(tmpdir))) == 1
     assert result.exit_code == 0
     with rasterio.open(output) as out:
@@ -123,22 +135,27 @@ def test_cli_reflectance_multiband_stack(tmpdir):
 
 def test_cli_parsemtl_good(tmpdir):
     runner = CliRunner()
-    result = runner.invoke(parsemtl,
-        ['tests/data/mtltest_LC80100202015018LGN00_MTL.txt'])
+    result = runner.invoke(
+                parsemtl,
+                ['tests/data/mtltest_LC80100202015018LGN00_MTL.txt'])
     assert result.exit_code == 0
-    assert json.loads(result.output) == dict({"L1_METADATA_FILE": {"METADATA_FILE_INFO":
-                    {"ORIGIN": "Image courtesy of the U.S. Geological Survey",
-                    "LANDSAT_SCENE_ID": "LC80100202015018LGN00",
-                    "PROCESSING_SOFTWARE_VERSION": "LPGS_2.4.0",
-                    "REQUEST_ID": "0501501184561_00001"},
-                    "PRODUCT_METADATA": {"SCENE_CENTER_TIME":
-                    "15:10:22.4142571Z", "DATE_ACQUIRED": "2015-01-18",
-                    "DATA_TYPE": "L1T"}}})
+    assert json.loads(result.output) == dict(
+        {"L1_METADATA_FILE":
+            {"METADATA_FILE_INFO":
+                {"ORIGIN":
+                    "Image courtesy of the U.S. Geological Survey",
+                 "LANDSAT_SCENE_ID": "LC80100202015018LGN00",
+                 "PROCESSING_SOFTWARE_VERSION": "LPGS_2.4.0",
+                 "REQUEST_ID": "0501501184561_00001"},
+             "PRODUCT_METADATA":
+                {"SCENE_CENTER_TIME": "15:10:22.4142571Z",
+                 "DATE_ACQUIRED": "2015-01-18",
+                 "DATA_TYPE": "L1T"}}})
 
 
 def test_cli_parsemtl_fail(tmpdir):
     runner = CliRunner()
-    result = runner.invoke(parsemtl,
-        ['tests/data/tiny_mtltest_LC80100202015018LGN00_MTL.txt'])
+    result = runner.invoke(
+              parsemtl,
+              ['tests/data/tiny_mtltest_LC80100202015018LGN00_MTL.txt'])
     assert result.exit_code != 0
-

--- a/tests/test_radiance.py
+++ b/tests/test_radiance.py
@@ -92,17 +92,18 @@ def test_calculate_radiance(test_data):
 
     assert isinstance(M, float)
     toa = radiance.radiance(tif, M, A)
-    toa_rescaled = toa_utils.rescale(toa, float(55000.0/2**16), np.uint16)
-    assert toa_rescaled.dtype == np.uint16
-    assert np.min(tif_output) == np.min(toa_rescaled)
-    assert int(np.max(tif_output)) == int(np.max(toa_rescaled))
-
-
+    toa_rescaled = toa_utils.rescale(toa, float(55000.0/2**16), np.uint8)
+    scale = float(np.iinfo(np.uint16).max) / float(np.iinfo(np.uint8).max)
+    tif_out_rescaled = np.clip(
+        (tif_output / scale),
+        1, np.iinfo(np.uint8).max).astype(np.uint8)
+    assert toa_rescaled.dtype == np.uint8
+    assert np.min(tif_out_rescaled) == np.min(toa_rescaled)
+    assert int(np.max(tif_out_rescaled)) == int(np.max(toa_rescaled))
 
 
 def test_calculate_radiance2(test_data):
     tif, tif_meta, tif_output, tif_shape, tif_output_meta, mtl = test_data
-
     M = toa_utils._load_mtl_key(mtl,
                                 ['L1_METADATA_FILE',
                                  'RADIOMETRIC_RESCALING',
@@ -114,8 +115,9 @@ def test_calculate_radiance2(test_data):
                                  'RADIANCE_ADD_BAND_'],
                                 5)
 
-    toa = toa_utils.rescale(radiance.radiance(tif, M, A),
-        float(55000.0/2**16), np.uint16)
+    toa = toa_utils.rescale(
+            radiance.radiance(tif, M, A),
+            float(55000.0/2**16), np.uint16)
     assert toa.dtype == np.uint16
     assert np.all(toa) < 1.5
     assert np.all(toa) >= 0.0
@@ -127,10 +129,11 @@ def test_calculate_landsat_radiance(test_var, capfd):
     rescale_factor = 1.0
     creation_options = {}
     band = 5
-    dst_dtype = 'uint16'
+    dst_dtype = 'uint8'
     processes = 1
-    radiance.calculate_landsat_radiance(src_path, src_mtl, dst_path,
-                                rescale_factor, creation_options, band,
-                                dst_dtype, processes)
+    radiance.calculate_landsat_radiance(
+        src_path, src_mtl, dst_path,
+        rescale_factor, creation_options, band,
+        dst_dtype, processes)
     out, err = capfd.readouterr()
     assert os.path.exists(dst_path)

--- a/tests/test_radiance.py
+++ b/tests/test_radiance.py
@@ -92,8 +92,8 @@ def test_calculate_radiance(test_data):
 
     assert isinstance(M, float)
     toa = radiance.radiance(tif, M, A)
-    toa_rescaled = toa_utils.rescale(toa, float(55000.0/2**16), np.float32)
-    assert toa_rescaled.dtype == np.float32
+    toa_rescaled = toa_utils.rescale(toa, float(55000.0/2**16), np.uint16)
+    assert toa_rescaled.dtype == np.uint16
     assert np.min(tif_output) == np.min(toa_rescaled)
     assert int(np.max(tif_output)) == int(np.max(toa_rescaled))
 
@@ -114,8 +114,9 @@ def test_calculate_radiance2(test_data):
                                  'RADIANCE_ADD_BAND_'],
                                 5)
 
-    toa = radiance.radiance(tif, M, A)
-    assert toa.dtype == np.float32
+    toa = toa_utils.rescale(radiance.radiance(tif, M, A),
+        float(55000.0/2**16), np.uint16)
+    assert toa.dtype == np.uint16
     assert np.all(toa) < 1.5
     assert np.all(toa) >= 0.0
 
@@ -126,7 +127,7 @@ def test_calculate_landsat_radiance(test_var, capfd):
     rescale_factor = 1.0
     creation_options = {}
     band = 5
-    dst_dtype = 'float32'
+    dst_dtype = 'uint16'
     processes = 1
     radiance.calculate_landsat_radiance(src_path, src_mtl, dst_path,
                                 rescale_factor, creation_options, band,

--- a/tests/test_reflectance.py
+++ b/tests/test_reflectance.py
@@ -75,7 +75,6 @@ def test_reflectance_negative_elevation():
         reflectance.reflectance(band, MR, AR, E)
 
 
-
 @pytest.fixture
 def test_var():
     src_path_b = 'tests/data/tiny_LC80460282016177LGN00_B2.TIF'
@@ -142,8 +141,8 @@ def test_calculate_reflectance(test_data):
     assert (np.sin(np.radians(E)) <= 1) & (-1 <= np.sin(np.radians(E)))
     assert isinstance(M, float)
     toa = reflectance.reflectance(tif_b, M, A, E)
-    toa_rescaled = toa_utils.rescale(toa, float(55000.0/2**16), np.float32)
-    assert toa_rescaled.dtype == np.float32
+    toa_rescaled = toa_utils.rescale(toa, float(55000.0/2**16), np.uint16)
+    assert toa_rescaled.dtype == np.uint16
     assert np.min(tif_output_single) == np.min(toa_rescaled)
     assert int(np.max(tif_output_single)) == int(np.max(toa_rescaled))
 
@@ -176,9 +175,10 @@ def test_calculate_reflectance2(test_data):
                                 date_collected,
                                 time_collected_utc)
     toa = reflectance.reflectance(tif_b, M, A, E)
-    assert toa.dtype == np.float32
-    assert np.all(toa) < 1.5
-    assert np.all(toa) >= 0.0
+    toa_rescaled = toa_utils.rescale(toa, float(55000.0/2**16), np.uint16)
+    assert toa_rescaled.dtype == np.uint16
+    assert np.all(toa_rescaled) < 1.5
+    assert np.all(toa_rescaled) >= 0.0
 
 
 def test_calculate_landsat_reflectance(test_var, capfd):
@@ -187,7 +187,7 @@ def test_calculate_landsat_reflectance(test_var, capfd):
     rescale_factor = 1.0
     creation_options = {}
     band = 5
-    dst_dtype = 'float32'
+    dst_dtype = 'uint16'
     processes = 1
     pixel_sunangle = False
     reflectance.calculate_landsat_reflectance([src_path], src_mtl, dst_path,

--- a/tests/test_reflectance.py
+++ b/tests/test_reflectance.py
@@ -7,11 +7,9 @@ import riomucho
 import pytest
 from rasterio.coords import BoundingBox
 from raster_tester.compare import affaux, upsample_array
-
-
-
 from rio_toa import toa_utils, sun_utils
 from rio_toa import reflectance
+
 
 def flex_compare(r1, r2, thresh=10):
     upsample = 4
@@ -21,8 +19,9 @@ def flex_compare(r1, r2, thresh=10):
     r1 = upsample_array(r1, upsample, frAff, toAff)
     r2 = upsample_array(r2, upsample, frAff, toAff)
     tdiff = np.abs(r1.astype(np.float64) - r2.astype(np.float64))
-    click.echo('{0} values exceed the threshold difference with a max variance of {1}'.format(
-        np.sum(tdiff > thresh), tdiff.max()), err=True)
+    click.echo('{0} values exceed the threshold'
+               'difference with a max variance of {1}'.format(
+                  np.sum(tdiff > thresh), tdiff.max()), err=True)
     return not np.any(tdiff > thresh)
 
 
@@ -62,6 +61,7 @@ def test_reflectance_wrong_shape():
 
     with pytest.raises(ValueError):
         reflectance.reflectance(band, 35.1, np.array([1, 3]), 90.0)
+
 
 def test_reflectance_negative_elevation():
     band = np.array([[0, 0, 0],
@@ -146,6 +146,35 @@ def test_calculate_reflectance(test_data):
     assert np.min(tif_output_single) == np.min(toa_rescaled)
     assert int(np.max(tif_output_single)) == int(np.max(toa_rescaled))
 
+def test_calculate_reflectance_uint8(test_data):
+    tif_b, tif_output_single, mtl = test_data[0], test_data[5], test_data[-1]
+
+    M = toa_utils._load_mtl_key(mtl,
+                                ['L1_METADATA_FILE',
+                                 'RADIOMETRIC_RESCALING',
+                                 'REFLECTANCE_MULT_BAND_'],
+                                5)
+    A = toa_utils._load_mtl_key(mtl,
+                                ['L1_METADATA_FILE',
+                                 'RADIOMETRIC_RESCALING',
+                                 'REFLECTANCE_ADD_BAND_'],
+                                5)
+    E = toa_utils._load_mtl_key(mtl,
+                                ['L1_METADATA_FILE',
+                                 'IMAGE_ATTRIBUTES',
+                                 'SUN_ELEVATION'])
+
+    assert (np.sin(np.radians(E)) <= 1) & (-1 <= np.sin(np.radians(E)))
+    assert isinstance(M, float)
+    toa = reflectance.reflectance(tif_b, M, A, E)
+    toa_rescaled = toa_utils.rescale(toa, float(55000.0/2**16), np.uint8)
+    scale = float(np.iinfo(np.uint16).max) / float(np.iinfo(np.uint8).max)
+    tif_out_rescaled = np.clip(
+        (tif_output_single / scale),
+        1, np.iinfo(np.uint8).max).astype(np.uint8)
+    assert toa_rescaled.dtype == np.uint8
+    assert np.min(tif_out_rescaled) == np.min(toa_rescaled)
+
 
 def test_calculate_reflectance2(test_data):
     tif_b, tif_shape, mtl = test_data[0], test_data[4], test_data[-1]
@@ -187,7 +216,7 @@ def test_calculate_landsat_reflectance(test_var, capfd):
     rescale_factor = 1.0
     creation_options = {}
     band = 5
-    dst_dtype = 'uint16'
+    dst_dtype = 'uint8'
     processes = 1
     pixel_sunangle = False
     reflectance.calculate_landsat_reflectance([src_path], src_mtl, dst_path,
@@ -214,7 +243,7 @@ def test_calculate_landsat_reflectance_single_pixel(test_var, capfd):
                                               [band], dst_dtype, processes,
                                               pixel_sunangle)
     out, err = capfd.readouterr()
-    
+
     with rio.open(dst_path) as created:
         with rio.open(expected_path) as expected:
             assert flex_compare(created.read(), expected.read())
@@ -227,7 +256,7 @@ def test_calculate_landsat_reflectance_stack_pixel(test_var, test_data, capfd):
     expected_path = 'tests/expected/ref2.tif'
     rescale_factor = float(55000.0/2**16)
     creation_options = {}
-    dst_dtype = 'uint16'
+    dst_dtype = 'uint8'
     processes = 1
     pixel_sunangle = True
 

--- a/tests/test_sun_utils.py
+++ b/tests/test_sun_utils.py
@@ -37,10 +37,12 @@ def test_data():
 
     return mtl1, mtl2, mtl3, mtl4
 
+
 def test_make_lat_lngs_n():
     lngs, lats = _create_lnglats((5, 5), [-120., 37., -119., 38.])
     assert lats[0, 0] > lats[-1, 0]
     assert lngs[0, -1] > lngs[0, 0]
+
 
 def test_make_lat_lngs_s():
     lngs, lats = _create_lnglats((5, 5), [-120., -38., -119., -37.])
@@ -77,7 +79,6 @@ def test_sun_angle2(test_data):
         (100, 100),
         mtl['L1_METADATA_FILE']['PRODUCT_METADATA']['DATE_ACQUIRED'],
         mtl['L1_METADATA_FILE']['PRODUCT_METADATA']['SCENE_CENTER_TIME'])
-
 
     assert np.mean(sunangles[0, :]) < np.mean(sunangles[-1, :]), "In N, Nrow should < Srow"
     assert sunangles.max() > mtl_sun

--- a/tests/test_toa_utils.py
+++ b/tests/test_toa_utils.py
@@ -70,6 +70,7 @@ def test_load_mtl_key():
 	clouds = _load_mtl_key(mtl_test, keys2, band=None)
 	assert clouds == 19.74
 
+
 def test_rescale():
 	arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3,3))
 	dtype = np.__dict__['uint16']
@@ -82,6 +83,7 @@ def test_rescale():
 	assert np.array_equal(rescaled_arr[mask], arr[mask].astype(int))
 	assert rescaled_arr.dtype == 'uint16'
 
+
 def test_rescale2():
 	arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3,3))
 	dtype = np.__dict__['uint8']
@@ -93,4 +95,12 @@ def test_rescale2():
 	assert np.all(rescaled_arr) >= 0.0
 	assert np.array_equal(rescaled_arr[mask], arr[mask].astype(int))
 	assert rescaled_arr.dtype == 'uint8'
+
+
+def test_rescale_dtype_error():
+	arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3,3))
+	dtype = np.__dict__['float32']
+	rescale_factor = 1.0
+	with pytest.raises(ValueError):
+		rescaled_arr = rescale(arr, rescale_factor, dtype)
 

--- a/tests/test_toa_utils.py
+++ b/tests/test_toa_utils.py
@@ -2,105 +2,109 @@ import pytest
 import numpy as np
 
 from rio_toa.toa_utils import (
-	_parse_bands_from_filename,
-	_load_mtl_key, _load_mtl, rescale)
+    _parse_bands_from_filename,
+    _load_mtl_key, _load_mtl, rescale)
+
 
 def test_parse_band_from_filename_default():
-	assert _parse_bands_from_filename(['data/LC81070352015122LGN00_B3.TIF'],
-		                              '.*/LC8.*\_B{b}.TIF') == [3]
+    assert _parse_bands_from_filename(['data/LC81070352015122LGN00_B3.TIF'],
+                                      '.*/LC8.*\_B{b}.TIF') == [3]
 
 
 def test_parse_band_from_filename_good():
-	assert _parse_bands_from_filename(['tiny_LC81070352015122LGN00_B3.tif'],
-		      						   'tiny_LC8.*_B{b}.tif') == [3]
+    assert _parse_bands_from_filename(
+        ['tiny_LC81070352015122LGN00_B3.tif'],
+        'tiny_LC8.*_B{b}.tif') == [3]
 
 
 def test_parse_band_from_filename_bad():
-	with pytest.raises(ValueError):
-		_parse_bands_from_filename(['LC81070352015122LGN00_B3.tif'],
-			     			        'LC8NOGOOD.*_B{b}.tif')
+    with pytest.raises(ValueError):
+        _parse_bands_from_filename(
+            ['LC81070352015122LGN00_B3.tif'],
+            'LC8NOGOOD.*_B{b}.tif')
 
 
 def test_parse_band_from_filename_bad2():
-	with pytest.raises(ValueError):
-		_parse_bands_from_filename(['data/tiny_LC81070352015122LGN00_B3.tif'],
-			                        '.*/LC8.*\_B{b}.TIF')
+    with pytest.raises(ValueError):
+        _parse_bands_from_filename(
+            ['data/tiny_LC81070352015122LGN00_B3.tif'],
+            '.*/LC8.*\_B{b}.TIF')
 
 
 def test_load_mtl():
-	src_mtl = 'tests/data/LC80100202015018LGN00_MTL.json'
-	mtl = _load_mtl(src_mtl)
-	assert isinstance(mtl, dict)
+    src_mtl = 'tests/data/LC80100202015018LGN00_MTL.json'
+    mtl = _load_mtl(src_mtl)
+    assert isinstance(mtl, dict)
 
 
 def test_load_txt_mtl_1():
-	txtmtl = _load_mtl('tests/data/LC81060712016134LGN00_MTL.txt')
-	jsonmtl = _load_mtl('tests/data/LC81060712016134LGN00_MTL.json')
+    txtmtl = _load_mtl('tests/data/LC81060712016134LGN00_MTL.txt')
+    jsonmtl = _load_mtl('tests/data/LC81060712016134LGN00_MTL.json')
 
-	for k in jsonmtl['L1_METADATA_FILE'].keys():
-		assert k in txtmtl['L1_METADATA_FILE']
-		assert jsonmtl['L1_METADATA_FILE'][k] == txtmtl['L1_METADATA_FILE'][k]
+    for k in jsonmtl['L1_METADATA_FILE'].keys():
+        assert k in txtmtl['L1_METADATA_FILE']
+        assert jsonmtl['L1_METADATA_FILE'][k] == txtmtl['L1_METADATA_FILE'][k]
 
 
 def test_load_txt_mtl_2():
-	txtmtl = _load_mtl('tests/data/LC80100202015018LGN00_MTL.txt')
-	jsonmtl = _load_mtl('tests/data/LC80100202015018LGN00_MTL.json')
+    txtmtl = _load_mtl('tests/data/LC80100202015018LGN00_MTL.txt')
+    jsonmtl = _load_mtl('tests/data/LC80100202015018LGN00_MTL.json')
 
-	for k in jsonmtl['L1_METADATA_FILE'].keys():
-		assert k in txtmtl['L1_METADATA_FILE']
-		assert jsonmtl['L1_METADATA_FILE'][k] == txtmtl['L1_METADATA_FILE'][k]
+    for k in jsonmtl['L1_METADATA_FILE'].keys():
+        assert k in txtmtl['L1_METADATA_FILE']
+        assert jsonmtl['L1_METADATA_FILE'][k] == txtmtl['L1_METADATA_FILE'][k]
 
 
 def test_load_mtl_key():
-	mtl_test = {u'L1_METADATA_FILE': {u'IMAGE_ATTRIBUTES': 
-				 {u'CLOUD_COVER': 19.74,
-				  u'SUN_AZIMUTH': 164.19023018},
-			    u'TIRS_THERMAL_CONSTANTS':
-				 {u'K1_CONSTANT_BAND_10': 774.89, 
-				  u'K1_CONSTANT_BAND_11': 480.89},
-			    u'RADIOMETRIC_RESCALING':
-				 {u'RADIANCE_ADD_BAND_1': -64.85281,
-				  u'RADIANCE_MULT_BAND_1': 0.012971}}}
+    mtl_test = {u'L1_METADATA_FILE':
+                {u'IMAGE_ATTRIBUTES':
+                    {u'CLOUD_COVER': 19.74,
+                     u'SUN_AZIMUTH': 164.19023018},
+                    u'TIRS_THERMAL_CONSTANTS':
+                        {u'K1_CONSTANT_BAND_10': 774.89,
+                         u'K1_CONSTANT_BAND_11': 480.89},
+                    u'RADIOMETRIC_RESCALING':
+                        {u'RADIANCE_ADD_BAND_1': -64.85281,
+                         u'RADIANCE_MULT_BAND_1': 0.012971}}}
 
-	keys = ['L1_METADATA_FILE', 'TIRS_THERMAL_CONSTANTS','K1_CONSTANT_BAND_']
-	K11 = _load_mtl_key(mtl_test, keys, band=11)
-	assert K11 == 480.89
+    keys = ['L1_METADATA_FILE', 'TIRS_THERMAL_CONSTANTS', 'K1_CONSTANT_BAND_']
+    K11 = _load_mtl_key(mtl_test, keys, band=11)
+    assert K11 == 480.89
 
-	keys2 = ['L1_METADATA_FILE', 'IMAGE_ATTRIBUTES', 'CLOUD_COVER']
-	clouds = _load_mtl_key(mtl_test, keys2, band=None)
-	assert clouds == 19.74
+    keys2 = ['L1_METADATA_FILE', 'IMAGE_ATTRIBUTES', 'CLOUD_COVER']
+    clouds = _load_mtl_key(mtl_test, keys2, band=None)
+    assert clouds == 19.74
 
 
 def test_rescale():
-	arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3,3))
-	dtype = np.__dict__['uint16']
-	rescale_factor = 1.0
-	rescaled_arr = rescale(arr, rescale_factor, dtype)
-	mask = (rescaled_arr != np.iinfo(np.uint16).max) & (rescaled_arr != 1.0)
+    arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3, 3))
+    dtype = np.__dict__['uint16']
+    rescale_factor = 1.0
+    rescaled_arr = rescale(arr, rescale_factor, dtype)
+    mask = (rescaled_arr != np.iinfo(np.uint16).max) & (rescaled_arr != 1.0)
 
-	assert np.all(rescaled_arr) <= np.iinfo(np.uint16).max
-	assert np.all(rescaled_arr) >= 0.0
-	assert np.array_equal(rescaled_arr[mask], arr[mask].astype(int))
-	assert rescaled_arr.dtype == 'uint16'
+    assert np.all(rescaled_arr) <= np.iinfo(np.uint16).max
+    assert np.all(rescaled_arr) >= 0.0
+    assert np.array_equal(rescaled_arr[mask], arr[mask].astype(int))
+    assert rescaled_arr.dtype == 'uint16'
 
 
 def test_rescale2():
-	arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3,3))
-	dtype = np.__dict__['uint8']
-	rescale_factor = 1.0
-	rescaled_arr = rescale(arr, rescale_factor, dtype)
-	mask = (rescaled_arr != np.iinfo(dtype).max) & (rescaled_arr != 1.0)
+    arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3, 3))
+    dtype = np.__dict__['uint8']
+    rescale_factor = 1.0
+    rescaled_arr = rescale(arr, rescale_factor, dtype)
+    mask = (rescaled_arr != np.iinfo(dtype).max) & (rescaled_arr != 1.0)
 
-	assert np.all(rescaled_arr) <= np.iinfo(dtype).max
-	assert np.all(rescaled_arr) >= 0.0
-	assert np.array_equal(rescaled_arr[mask], arr[mask].astype(int))
-	assert rescaled_arr.dtype == 'uint8'
+    assert np.all(rescaled_arr) <= np.iinfo(dtype).max
+    assert np.all(rescaled_arr) >= 0.0
+    assert np.array_equal(rescaled_arr[mask], arr[mask].astype(int))
+    assert rescaled_arr.dtype == 'uint8'
 
 
 def test_rescale_dtype_error():
-	arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3,3))
-	dtype = np.__dict__['float32']
-	rescale_factor = 1.0
-	with pytest.raises(ValueError):
-		rescaled_arr = rescale(arr, rescale_factor, dtype)
-
+    arr = np.array(np.linspace(0.0, 1.5, num=9).reshape(3, 3))
+    dtype = np.__dict__['float32']
+    rescale_factor = 1.0
+    with pytest.raises(ValueError):
+        rescaled_arr = rescale(arr, rescale_factor, dtype)


### PR DESCRIPTION
This PR cleans up some of the code and docstrings in [reflectance.py](https://github.com/mapbox/rio-toa/blob/5cb7b9848d2e49647de6846fee1da2b8931b05eb/rio_toa/reflectance.py), [radiance.py](https://github.com/mapbox/rio-toa/blob/5cb7b9848d2e49647de6846fee1da2b8931b05eb/rio_toa/radiance.py) and [toa_utils](https://github.com/mapbox/rio-toa/blob/5cb7b9848d2e49647de6846fee1da2b8931b05eb/rio_toa/toa_utils.py)
#### Changes made to functionality:
1. Click optional parameter **`--dst-dtype`**: Took out `float32`, `float64` and set the default as **`uint16`** for [radiance cli](https://github.com/mapbox/rio-toa/pull/18/commits/e97a8ff565517225c615e5af960b15b24f2cbdd9#diff-d526d88077ac04268b1226915c1fecffL27) and [reflectance cli](https://github.com/mapbox/rio-toa/pull/18/commits/e97a8ff565517225c615e5af960b15b24f2cbdd9#diff-d526d88077ac04268b1226915c1fecffL63).
#### Tests Added:
1. [test_rescale_dtype_error](https://github.com/mapbox/rio-toa/pull/18/commits/e97a8ff565517225c615e5af960b15b24f2cbdd9#diff-21ded7212d9b10a783afdbb2755775d3R100)
2. [test uint8 output](https://github.com/mapbox/rio-toa/pull/18/commits/72f34745c9e0a4a41b703e51ba209a1248d26002#diff-1da5d99b695c5726c59c987ad61b3f16R95)
#### Pep8
1. All files in tests: [commit 72f34](https://github.com/mapbox/rio-toa/blob/72f34745c9e0a4a41b703e51ba209a1248d26002/)
2. All files in rio_toa: [commit e97a8](https://github.com/mapbox/rio-toa/blob/e97a8ff565517225c615e5af960b15b24f2cbdd9/rio_toa/reflectance.py)
